### PR TITLE
feat(echo): add echoManager service for Reverb websocket integration

### DIFF
--- a/src/hooks/useNotifications.tsx
+++ b/src/hooks/useNotifications.tsx
@@ -1,0 +1,44 @@
+import { useEffect, useState } from "react";
+import { getEcho } from "../services/echoManager";
+
+type RentNotification = {
+  id: number;
+  message: string;
+  property_id?: number;
+};
+
+type NotificationPayload = {
+  id: string;
+  type: string;
+  notifiable_id: number;
+  notifiable_type: string;
+  data: RentNotification;
+};
+
+export function useNotifications(userId: number | null) {
+  const [notifications, setNotifications] = useState<RentNotification[]>([]);
+
+  useEffect(() => {
+    if (!userId) {
+      setNotifications([]);
+      return;
+    }
+
+    const echo = getEcho();
+    if (!echo) return;
+
+    const channelName = `App.Models.User.${userId}`;
+    const channel = echo.private(channelName);
+
+    channel.notification((notification: NotificationPayload | any) => {
+      const data: RentNotification = notification.data ?? notification;
+      setNotifications((prev) => [data, ...prev]);
+    });
+
+    return () => {
+      echo.leave(channelName);
+    };
+  }, [userId]);
+
+  return notifications;
+}

--- a/src/layouts/MainLayout/MainLayout.tsx
+++ b/src/layouts/MainLayout/MainLayout.tsx
@@ -3,15 +3,35 @@ import { Container } from "react-bootstrap";
 import { Outlet } from "react-router-dom";
 import styles from "./styles.module.css";
 import Navbar from "@components/Navbar/Navbar";
+import { useNotifications } from "@hooks/useNotifications";
+import { useSelector } from "react-redux";
+import type { RootState } from "@store/index";
+import { toast } from "react-toastify";
 
 const { layoutContainer, wrapper } = styles;
 
 function MainLayout() {
+  const user = useSelector((state: RootState) => state.Authslice.user);
+  const jwt = useSelector((state: RootState) => state.Authslice.jwt);
 
+  // always call the hook, pass null if not logged in (for test only)
+  const notifications = useNotifications(jwt && user?.id ? user.id : null);
+console.log(notifications);
 
   return (
     <Container fluid className={layoutContainer}>
       <Navbar />
+
+      {notifications.length > 0 && (
+        <div className="p-2">
+          {notifications.map((n, i) => (
+            <div key={i} >
+              {toast.success(n.message)}
+            </div>
+          ))}
+        </div>
+      )}
+
       <div className={wrapper}>
         <Outlet />
       </div>
@@ -21,3 +41,4 @@ function MainLayout() {
 }
 
 export default MainLayout;
+

--- a/src/services/echoManager.ts
+++ b/src/services/echoManager.ts
@@ -1,0 +1,47 @@
+// src/services/echoManager.ts
+import EchoBase from "laravel-echo";
+import Pusher from "pusher-js";
+
+// Force Echo to use the "pusher" generic since Reverb is Pusher-compatible
+type Echo = EchoBase<"pusher">;
+const EchoClass = EchoBase as unknown as { new (opts: any): Echo };
+
+let echo: Echo | null = null;
+
+export const getEcho = () => echo;
+
+export const initEcho = (jwt: string) => {
+  // cleanup old instance
+  if (echo) echo.disconnect();
+
+  // required for laravel-echo + pusher/reverb
+  (window as any).Pusher = Pusher;
+
+  // initialize
+  echo = new EchoClass({
+    broadcaster: "reverb",
+    key: import.meta.env.VITE_REVERB_APP_KEY,
+    wsHost: import.meta.env.VITE_REVERB_HOST,
+    wsPort: import.meta.env.VITE_REVERB_PORT,
+    wssPort: import.meta.env.VITE_REVERB_PORT,
+    forceTLS: import.meta.env.VITE_REVERB_SCHEME === "https",
+    enabledTransports: ["ws", "wss"],
+
+    authEndpoint: "http://127.0.0.1:8000/broadcasting/auth",
+    auth: {
+      headers: {
+        Authorization: `Bearer ${jwt}`,
+        Accept: "application/json",
+      },
+    },
+  });
+
+  return echo;
+};
+
+export const disconnectEcho = () => {
+  if (echo) {
+    echo.disconnect();
+    echo = null;
+  }
+};


### PR DESCRIPTION
- Implemented echoManager with initEcho, disconnectEcho, and getEcho helpers
- Configured laravel-echo with Reverb (Pusher-compatible) connection
- Added JWT-based auth headers for private channel authentication
- Ensured cleanup of old Echo instances to prevent duplicate connections
- Supported both ws and wss with dynamic TLS enforcement